### PR TITLE
Dev/Load Marionette as an external dependency

### DIFF
--- a/marionette.flow.js
+++ b/marionette.flow.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Flow = require('flow');
-var Marionette = window.Marionette;
+var Marionette = require('backbone.marionette');
 
 Flow.Action.ShowAction = require('./lib/show_action');
 Flow.Builder.MarionetteBuilder = require('./lib/marionette_builder');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,16 @@ var fullOutputConfig = {
     entry: {
         library: './marionette.flow'
     },
+    externals: [
+        {
+            'backbone.marionette': {
+                root: 'Marionette',
+                commonjs2: 'backbone.marionette',
+                commonjs: 'backbone.marionette',
+                amd: 'backbone.marionette',
+            }
+        }
+    ],
 };
 
 var minfiedOutputConfig = {
@@ -22,6 +32,16 @@ var minfiedOutputConfig = {
     entry: {
         library: './marionette.flow'
     },
+    externals: [
+        {
+            'backbone.marionette': {
+                root: 'Marionette',
+                commonjs2: 'backbone.marionette',
+                commonjs: 'backbone.marionette',
+                amd: 'backbone.marionette',
+            }
+        }
+    ],
     plugins: [
         new webpack.optimize.UglifyJsPlugin({
             compress: false,


### PR DESCRIPTION
This PR correctly describes `backbone.marionette` as an external dependency, with UMD hooks importing it via commonjs, amd, and root.